### PR TITLE
Replace array copying by loop with faster REPLACE calls

### DIFF
--- a/common.lisp
+++ b/common.lisp
@@ -169,18 +169,16 @@
         (values time-sec (floor (* 1000000 time-frac))))
       nil))
 
-(defun append-array (arr1 arr2 &key element-type)
+(defun append-array (arr1 arr2)
   "Create an array, made up of arr1 followed by arr2."
   (let ((arr1-length (length arr1))
         (arr2-length (length arr2)))
     (let ((arr (make-array (+ arr1-length arr2-length)
-                           :element-type element-type)))
-      (dotimes (i arr1-length)
-        (setf (aref arr i) (aref arr1 i)))
-      (dotimes (i arr2-length)
-        (setf (aref arr (+ arr1-length i)) (aref arr2 i)))
+                           :element-type (array-element-type arr1))))
+      (replace arr arr1 :start1 0)
+      (replace arr arr2 :start1 arr1-length)
       arr)))
-
+      
 (defun add-event-loop-exit-callback (fn)
   "Add a function to be run when the event loop exits."
   (push fn *event-loop-end-functions*))


### PR DESCRIPTION
AFAIK The APPEND-ARRAY call only gets used when draining HTTP client and server requests. Using REPLACE instead of looping is a bit faster in ClozureCL and A LOT faster in Lispworks (factor 10). I didn't check SBCL or other implementations so far.

This does not solve the heavy consing that occurs when appending this arrays though. Each append drops the whole old array AND the new input array. So another implementation strategy for draining would be even better: Resuse arrays and preallocation or collecting in a list. So you could either always adjust the first array (doubling its size on each reallocation) or you could just collect the buffers into a simple list and if all is done, go one time over the list, allocate a big enough result buffer and copy all over.
