### PR TITLE
Fix DRAIN-EVBUFFER following my APPEND-ARRAY optimization

### DIFF
--- a/tcp.lisp
+++ b/tcp.lisp
@@ -135,7 +135,7 @@
     (read-socket-data evbuffer
                       (lambda (data)
                         (if body
-                            (setf body (append-array body data :element-type '(unsigned-byte 8)))
+                            (setf body (append-array body data))
                             data))
                       :socket-is-evbuffer t)
     body))


### PR DESCRIPTION
My optimization broke DRAIN-EVBUFFER because I removed the element-type key-arg and didn't check in the necessary change to DRAIN-EVBUFFER.
