### PR TITLE
tcp-ssl: only call event-cb on error if it's not nil 

### DIFF
--- a/tcp-ssl.lisp
+++ b/tcp-ssl.lisp
@@ -54,10 +54,11 @@
         (unless (zerop errcode)
           (setf events le:+bev-event-error+)
           ;; we found an error. grab the errstring and call the event-cb
-          (cffi:with-foreign-object (buf :unsigned-char 256)
-            (cl+ssl::err-error-string errcode buf)
-            (let ((str (cffi:foreign-string-to-lisp buf)))
-              (run-event-cb event-cb (make-instance 'tcp-ssl-error :code errcode :msg str))))
+          (when event-cb
+            (cffi:with-foreign-object (buf :unsigned-char 256)
+              (cl+ssl::err-error-string errcode buf)
+              (let ((str (cffi:foreign-string-to-lisp buf)))
+                (run-event-cb event-cb (make-instance 'tcp-ssl-error :code errcode :msg str)))))
           ;; make sure to close the socket after an error
           (close-socket socket))
         ;; call directly into the tcp-event-cb function


### PR DESCRIPTION
If event-cb is nil, the existing code raises an error because event-cb is
nil. Let's prevent this.
