### PR TITLE
Ensure octet-vector creation for stream-write-byte

### DIFF
--- a/tcp-stream.lisp
+++ b/tcp-stream.lisp
@@ -68,7 +68,8 @@
 
 (defmethod stream-write-byte ((stream async-output-stream) byte)
   "Write one byte to the underlying socket."
-  (stream-write-sequence stream (vector byte) 0 1))
+  (stream-write-sequence stream (make-array 1 :element-type 'octet
+					      :initial-element byte) 0 1))
   
 (defmethod send-buffered-data ((stream async-output-stream))
   "Take data we've buffered between initial sending and actual socket connection


### PR DESCRIPTION
`STREAM-WRITE-BYTE` method for `ASYNC-OUTPUT-STREAM` creates a simple vector with `(vector byte)`.

With `*BUFFER-WRITES*` enabled, this sequence is passed down to `WRITE-SOCKET-DATA` and `WRITE-TO-BUFFER`. The latter declares its `SEQ` argument to be an `OCTET-VECTOR`, not a simple vector. The actual parameter type mismatches the declaration.

Let's create an octet-vector in `STREAM-WRITE-BYTE` instead of a simple vector. (That's what my patch does).

(There's also a more general problem with `STREAM-WRITE-SEQUENCE` method that is not really prepared to work with anything but an `OCTET-VECTOR`. If we solve it by throwing in some `TYPECASE`/`COERCE`, _this_ patch will become unnecessary, but still useful to avoid one extra array consing per `WRITE-BYTE`).
