### PR TITLE
Improve event loop shutdown diagnostics, reenable PIPE-CONNECT-FAIL test.

### DIFF
--- a/test/pipe.lisp
+++ b/test/pipe.lisp
@@ -42,7 +42,6 @@
     (is (= client-replies 2) "number of replies sent to client")
     (is (string= client-data "thxlol thxlol ") "received client data")))
 
-#|
 (test pipe-connect-fail
   "Make sure a pipe connection fails"
   (let ((num-err 0))
@@ -59,7 +58,6 @@
             :data "hai"
             :read-timeout 1))))
     (is (= num-err 1))))
-|#
 
 (test pipe-server-close
   "Make sure a pipe-server closes gracefully"


### PR DESCRIPTION
No longer enter infinite loop when there are handles that cannot be
closed for some reason. Do at most 100000 iterations, then show
warning and dump currently active handles.
I encounter event loop shutdown problems from time to time
and this will perhaps be of some help with debugging.

PIPE-CONNECT-FAIL was probably hanging due to HANDLE-TYPE
problem in cl-libuv, see orthecreedence/cl-libuv#3