### PR TITLE
More *BUFFER-WRITES* related fixes.

### DIFF
--- a/src/socket.lisp
+++ b/src/socket.lisp
@@ -153,7 +153,7 @@
              (unless (socket-closed-p socket)
                (setf (socket-buffering-p socket) nil)
                (write-to-uvstream (socket-c socket)
-                                  (buffer-output (socket-buffer socket)) :start start :end end)
+                                  (buffer-output (socket-buffer socket)))
                (setf (socket-buffer socket) (make-buffer))))))
         (t
          (call-next-method))))

--- a/src/socket.lisp
+++ b/src/socket.lisp
@@ -167,6 +167,11 @@
     (setf (socket-buffer socket) (make-buffer))
     (write-socket-data socket pending :force t)))
 
+(defmethod close-streamish ((socket socket) &key force &allow-other-keys)
+  (when (and (not force) (socket-buffering-p socket))
+    (write-pending-socket-data socket))
+  (call-next-method))
+
 (define-c-callback socket-connect-cb :void ((req :pointer) (status :int))
   "Called when an outgoing socket connects."
   (let* ((uvstream (deref-data-from-pointer req))


### PR DESCRIPTION
Flushing socket buffer before closing is perhaps the right thing to do unless FORCE argument is true.
Also, START/END handling was broken in STREAMISH-WRITE implementation for sockets when *BUFFER-WRITES* was true.