### PR TITLE
Safeguard against late dns-lookup connect callbacks during event loop shutdown

### DIFF
--- a/src/tcp.lisp
+++ b/src/tcp.lisp
@@ -56,7 +56,10 @@
                (let ((req (uv:alloc-req :connect)))
                  ;; make sure we can grab the original uvstream from the req
                  (attach-data-to-pointer req uvstream)
-                 (uv:uv-tcp-connect req uvstream sockaddr (cffi:callback socket-connect-cb))))))
+                 (if (zerop (uv:uv-is-closing uvstream))
+                     (uv:uv-tcp-connect req uvstream sockaddr (cffi:callback socket-connect-cb))
+                     (warn "aborting connection to ~a:~s on a tcp socket that is being closed: ~
+                            ~s (uvstream ~s)~%" host port socket/stream uvstream))))))
       (if (ip-address-p host)
           ;; got an IP so just connect directly
           (do-connect host port)


### PR DESCRIPTION
Sometimes dns-lookup callback may be invoked during event loop shutdown
or after the socket was explicitly closed. That led to
`!uv__io_active(&stream->io_watcher, UV__POLLIN | UV__POLLOUT)`
(stream.c) assertion errors in libuv due to `uv_tcp_connect()`
call on the socket.