### PR TITLE
Add reverse-dns-lookup

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -96,9 +96,8 @@
            ;; dns conditions
            #:dns-error
            ;; dns functions
-           #:start-dns-logging
-           #:stop-dns-logging
            #:dns-lookup
+           #:reverse-dns-lookup
 
            ;; streamish/socket/tcp/pipe conditions/accessors
            #:streamish

--- a/src/util/foreign.lisp
+++ b/src/util/foreign.lisp
@@ -20,10 +20,7 @@
 (defmacro with-foreign-object* ((var type &key (zero t) (initial (when zero #x0))) bindings &body body)
   "Convenience macro, makes creation and initialization of CFFI types easier.
    Emphasis on initialization."
-  (let ((type (if (eq type 'uv:addrinfo)
-                  'uv:addrinfo
-                  type))
-        (type-size (cffi:foreign-type-size (list :struct type))))
+  (let ((type-size (cffi:foreign-type-size (list :struct type))))
     `(cffi:with-foreign-object (,var :unsigned-char ,type-size)
        ,(when initial
           `(cffi:foreign-funcall "memset" :pointer ,var :unsigned-char ,initial :unsigned-char ,(if type-size type-size `(cffi:foreign-type-size '(:struct ,type)))))

--- a/test/dns.lisp
+++ b/test/dns.lisp
@@ -73,3 +73,29 @@
                       (incf num-err)
                       (error ev)))))
     (is (= num-err 1))))
+
+(test reverse-dns-lookup-ipv4
+  "Test IPV4 family"
+  (multiple-value-bind (host)
+      (async-let ((host nil))
+        (test-timeout 3)
+        (as:reverse-dns-lookup "8.8.8.8"
+          (lambda (host* service)
+            (declare (ignore service))
+            (setf host host*))
+          :event-cb (lambda (ev) (error ev))))
+    (is (string= host "google-public-dns-a.google.com"))))
+
+(test reverse-dns-lookup-ipv6
+  "Test IPV6 family"
+  (multiple-value-bind (host)
+      (handler-case
+        (async-let ((host nil))
+          (test-timeout 3)
+          (as:reverse-dns-lookup "2001:4860:4860::8888"
+            (lambda (host* service)
+              (declare (ignore service))
+              (setf host host*))
+            :event-cb (lambda (ev) (error ev))))
+        (error (e) (format nil "(~a) ~a" (as:event-errcode e) (as:event-errmsg e))))
+    (is (string= host "google-public-dns-a.google.com"))))


### PR DESCRIPTION
This is a fairly straightforward export of [uv_getnameinfo](http://docs.libuv.org/en/latest/dns.html#c.uv_getnameinfo), similar to `dns-lookup`.

`reverse-dns-lookup` makes the callback be called with HOST and SERVICE arguments, but the service argument after this change will always be "0", so it should probably just be dropped. [This patch](https://github.com/orivej/cl-async/commit/4967631ee83c2e44d3e566e5697b18654d172b6d) adds the port argument (to look service name from `/etc/services` on Linux), but somehow the port number used for lookup is the specified port times 256. I also don't see any use in bundling HOST resolution and SERVICE name resolution in the same function.