### PR TITLE
Stream read sequence

### DIFF
--- a/src/async-stream.lisp
+++ b/src/async-stream.lisp
@@ -99,9 +99,9 @@
   "Attempt to read a sequence of bytes from the underlying streamish."
   (let* ((buffer (buffer-output (stream-buffer stream)))
          (numbytes (min (length buffer) (- end start)))
-         (bytes (subseq buffer start numbytes)))
+         (bytes (subseq buffer 0 numbytes)))
     (setf (stream-buffer stream) (make-buffer (subseq buffer numbytes)))
-    (replace sequence bytes)
+    (replace sequence bytes :start1 start :end1 end)
     (length bytes)))
 
 ;;;; compatibility

--- a/src/async-stream.lisp
+++ b/src/async-stream.lisp
@@ -69,7 +69,7 @@
 (defmethod stream-write-byte ((stream async-output-stream) byte)
   "Write one byte to the underlying streamish."
   (stream-write-sequence stream (make-array 1 :element-type 'octet
-					      :initial-element byte) 0 1))
+                                              :initial-element byte) 0 1))
 
 (defmethod send-buffered-data ((stream async-output-stream))
   "Take data we've buffered between initial sending and actual streamish
@@ -99,7 +99,7 @@
   "Attempt to read a sequence of bytes from the underlying streamish."
   (let* ((buffer (buffer-output (stream-buffer stream)))
          (numbytes (min (length buffer) (- end start)))
-         (bytes (subseq buffer start (min (length buffer) numbytes))))
+         (bytes (subseq buffer start numbytes)))
     (setf (stream-buffer stream) (make-buffer (subseq buffer numbytes)))
     (replace sequence bytes)
     (length bytes)))

--- a/src/async-stream.lisp
+++ b/src/async-stream.lisp
@@ -98,11 +98,10 @@
 (defmethod stream-read-sequence ((stream async-input-stream) sequence start end &key)
   "Attempt to read a sequence of bytes from the underlying streamish."
   (let* ((buffer (buffer-output (stream-buffer stream)))
-         (numbytes (min (length buffer) (- end start)))
-         (bytes (subseq buffer 0 numbytes)))
+         (numbytes (min (length buffer) (- end start))))
     (setf (stream-buffer stream) (make-buffer (subseq buffer numbytes)))
-    (replace sequence bytes :start1 start :end1 end)
-    (length bytes)))
+    (replace sequence buffer :start1 start :end1 end)
+    numbytes))
 
 ;;;; compatibility
 


### PR DESCRIPTION
At [this line](https://github.com/orthecreedence/cl-async/blob/master/src/async-stream.lisp#L102) in stream-read-sequence, you're doing `(subseq buffer start <end>)`, but `start` is an index into the output sequence, not an index into the internal stream buffer. This causes problems when trying to fill a large sequence from multiple reads on a tcp connection.

This branch fixes that and cleans the function up a little. There should be a small performance increase, since the new version doesn't cons up an intermediate sequence to copy into the output. You could get more out of it by storing a read cursor in the stream instead of using `subseq` on the internal buffer, but that's a bit more involved.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/orthecreedence/cl-async/136)
<!-- Reviewable:end -->
