### PR TITLE
Pointer data mem leak

### DIFF
--- a/src/dns.lisp
+++ b/src/dns.lisp
@@ -25,6 +25,7 @@
           ;; error, signal
           (run-event-cb 'event-handler status event-cb))
       (uv:free-req req)
+      (free-pointer-data req :preserve-pointer t)
       (uv:uv-freeaddrinfo addrinfo))))
 
 (defun dns-lookup (host resolve-cb &key event-cb (family +af-inet+))
@@ -58,7 +59,8 @@
       (if (zerop status)
           (funcall resolve-cb hostname service)
           (run-event-cb 'event-handler status event-cb))
-      (uv:free-req req))))
+      (uv:free-req req)
+      (free-pointer-data req :preserve-pointer t))))
 
 (defun reverse-dns-lookup (ip resolve-cb &key event-cb)
   "Perform reverse DNS lookup on IP specifier as string.  Call RESOLVE-CB with

--- a/src/streamish.lisp
+++ b/src/streamish.lisp
@@ -157,6 +157,7 @@
   (declare (ignore status))
   (uv:free-req req)
   (let ((uvstream (car (deref-data-from-pointer req))))
+    (free-pointer-data req :preserve-pointer t)
     (when (zerop (uv:uv-is-closing uvstream))
       (uv:uv-close uvstream (cffi:callback streamish-close-cb)))))
 


### PR DESCRIPTION
Some stale data are kept in `*data-registry*` and `*function-registry*`, causing memory leaks. This PR tries to fix them.

I was able to track down two leaking spots in `dns.lisp` and one in `streamish.lisp`, all related to the **pointer data** infrastructure. In this PR I wrote tests for the DNS cases, but didn't figure out how to properly test the case in `streamish.lisp`.