### PR TITLE
Use default :method  in calling create-ssl-ctx in tcp-ssl-connect-new

### DIFF
--- a/src/ssl/tcp.lisp
+++ b/src/ssl/tcp.lisp
@@ -322,7 +322,7 @@
                      (stream-socket socket/stream)
                      socket/stream))
          (ctx (or ssl-ctx
-                  (let ((ctx (create-ssl-ctx :method :tlsv1-client :options ssl-options)))
+                  (let ((ctx (create-ssl-ctx :options ssl-options)))
                     (ssl-ctx-set-default-verify-paths ctx)
                     ;; TODO better verify support
                     (ssl-ctx-set-verify ctx +ssl-verify-none+ (cffi:null-pointer))


### PR DESCRIPTION
Hey Andrew,

I am using a tweaked version of https://github.com/TBRSS/cl-stripe-client which uses your drakma-async and Stripe sent me an email saying I needed to migrate from TLS 1.0 to TLS 1.2 (see https://support.stripe.com/questions/how-do-i-upgrade-my-stripe-integration-from-tls-1-0-to-tls-1-2).

I tracked the issue down to ssl/tcp.lisp in cl-async-ssl where the call to `create-ssl-ctx` in `tcp-ssl-connect-new` was explicitly specifying `:tlsv1-client`.  My limited googling (http://stackoverflow.com/questions/23709664/openssl-let-the-server-and-client-negotiate-the-method) makes me think this is not the best default choice, and indeed `create-ssl-ctx` itself seems to have a better default,  So this pull request is just to use the default of `:sslv23`.  

This makes Stripe happy now but I am not sure how it might effect other uses of cl-async-ssl...


