### PR TITLE
Fix private key path in tcp-ssl-server-new

### DIFF
--- a/src/ssl/tcp.lisp
+++ b/src/ssl/tcp.lisp
@@ -378,7 +378,7 @@
                                      (:pem +ssl-filetype-pem+)
                                      (:asn1 +ssl-filetype-asn1+)
                                      (t +ssl-x509-filetype-default+)))
-                             (res (ssl-ctx-use-privatekey-file ctx (namestring certificate) type)))
+                             (res (ssl-ctx-use-privatekey-file ctx (namestring key) type)))
                         (when (<= res 0)
                           (let* ((code (ssl-err-get-error))
                                  (msg (ssl-err-error-string code (cffi:null-pointer))))


### PR DESCRIPTION
Looks like `key` should be loaded here instead of `certificate`