### PR TITLE
WIP Acknowledge init change for libssl 1

### DIFF
--- a/src/ssl/package.lisp
+++ b/src/ssl/package.lisp
@@ -51,13 +51,14 @@
 ;; NOTE: the loading code is verbatim from cl+ssl
 
 (eval-when (:compile-toplevel :load-toplevel)
-  ;; OpenBSD needs to load libcrypto before libssl
-  #+openbsd
+  #+(or openbsd linux)
   (progn
     (cffi:define-foreign-library libcrypto
       (:openbsd (:or "libcrypto.so.20.1"
                      "libcrypto.so.19.0"
-                     "libcrypto.so.18.0")))
+                     "libcrypto.so.18.0"))
+      (:linux (:or "libcrypto.so.1.1"
+                   "libcrypto.so.1.0.2")))
     (cffi:use-foreign-library libcrypto))
 
   (cffi:define-foreign-library libssl

--- a/src/ssl/tcp.lisp
+++ b/src/ssl/tcp.lisp
@@ -29,9 +29,12 @@
 
   (defun ensure-init (&key from-load)
     (unless *ssl-init*
-      (cffi:foreign-funcall ("SSL_library_init") :void)
-      (cffi:foreign-funcall ("SSL_load_error_strings") :void)
-      (cffi:foreign-funcall ("ERR_load_BIO_strings") :void)
+      (if (cffi:foreign-symbol-pointer "SSL_library_init" )
+          (cffi:foreign-funcall "SSL_library_init" :void)
+          (cffi:foreign-funcall "OPENSSL_init_ssl" :int 0 :int 0))
+      (when (cffi:foreign-symbol-pointer "SSL_load_error_strings")
+        (cffi:foreign-funcall "SSL_load_error_strings" :void))
+      (cffi:foreign-funcall "ERR_load_BIO_strings" :void)
       (unless from-load
         (setf *ssl-init* t)))))
 


### PR DESCRIPTION
I started to work on a fix for #154.

It seems that initialisation rules for SSL changed with version 1, see:

  https://wiki.openssl.org/index.php/Library_Initialization

unfortunately the library version number is not static data but is hidden in a macro. Using this patch we can `(ql:quickload "cl-async-ssl") in Debian Stretch for instance. However the library does not seem to be correctly initialised because the following code fails with

```
Error: #<TCP-SSL-ERROR NIL: 336236705: error creating SSL context: library has no ciphers {1002489F13}>
```

``` lisp
(ql:quickload "drakma-async")
(defun my-http-request ()
  (blackbird:catcher
    (blackbird:multiple-promise-bind (body status headers)
        (das:http-request "https://www.google.com/")
      (format t "Status: ~a~%" status)
      (format t "Headers: ~s~%" headers)
      (format t "Body: ~a~%" (if (stringp body) body (babel:octets-to-string body))))
    (drakma-async:http-eof ()
      (format t "Server hung up unexpectedly =[~%"))
    (error (e)
      (format t "Error: ~a~%" e))))

(as:start-event-loop #'my-http-request)
```

I am not familiar with libssl so maybe has someone else an idea about how to really fix this?