### PR TITLE
Expose stream to incoming sockets

### DIFF
--- a/src/socket.lisp
+++ b/src/socket.lisp
@@ -239,7 +239,7 @@
                 (progn
                   (attach-data-to-pointer uvstream (list :streamish socket :stream stream))
                   (save-callbacks uvstream (list :read-cb read-cb :event-cb event-cb))
-                  (when connect-cb (funcall connect-cb socket))
+                  (when connect-cb (funcall connect-cb (or stream socket)))
                   (uv:uv-read-start uvstream
                                     (cffi:callback streamish-alloc-cb)
                                     (cffi:callback streamish-read-cb)))


### PR DESCRIPTION
It's good to have stream available when server needs to communicate first after client connects. The connect-cb already works this way for outgoing sockets.