### PR TITLE
try to load latest ssl/crypto libraries on OpenBSD

### DIFF
--- a/src/ssl/package.lisp
+++ b/src/ssl/package.lisp
@@ -54,9 +54,7 @@
   #+(or openbsd linux)
   (progn
     (cffi:define-foreign-library libcrypto
-      (:openbsd (:or "libcrypto.so.20.1"
-                     "libcrypto.so.19.0"
-                     "libcrypto.so.18.0"))
+      (:openbsd "libcrypto.so")
       (:linux (:or "libcrypto.so.1.1"
                    "libcrypto.so.1.0.2")))
     (cffi:use-foreign-library libcrypto))
@@ -64,8 +62,7 @@
   (cffi:define-foreign-library libssl
     (:windows "libssl32.dll")
     (:darwin "libssl.dylib")
-    (:openbsd (:or "libssl.so.18.0" "libssl.so.17.1"
-                   "libssl.so.16.0" "libssl.so.15.1"))
+    (:openbsd "libssl.so")
     (:solaris (:or "/lib/64/libssl.so"
                    "libssl.so.0.9.8" "libssl.so" "libssl.so.4"))
     (:unix (:or "libssl.so.1.0.0" "libssl.so.0.9.8" "libssl.so" "libssl.so.4"))


### PR DESCRIPTION
OpenBSD fails to load provided libcrypto/ssl libraries when loading cl-async-ssl system.
The current version numbers are woefully outdated, ( 20.1 vs. 45.1 in currently used).

Easy fix would be to update the version numbers to match currently used numbers but the library will break as soons as libressl bumps versions. And how long list of version numbers should be kept in cl-async-ssl?

I think best option would be to make the code look for "libssl.so" and "libcrypto.so" libraries. This makes the OpenBSD linker to load the matching library with biggest major.minor version. This is often the right thing to do. I doubt theres enough OpenBSD Common Lisp hackers to keep hardcoded version numbers in sync.

