### PR TITLE
Make SSL work with libressl on linux

### DIFF
--- a/src/ssl/package.lisp
+++ b/src/ssl/package.lisp
@@ -56,7 +56,8 @@
     (cffi:define-foreign-library libcrypto
       (:openbsd "libcrypto.so")
       (:linux (:or "libcrypto.so.1.1"
-                   "libcrypto.so.1.0.2")))
+                   "libcrypto.so.1.0.2"
+                   "libcrypto.so")))
     (cffi:use-foreign-library libcrypto))
 
   (cffi:define-foreign-library libssl


### PR DESCRIPTION
LibreSSL has different version numbering, so while libssl uses the `libssl.so`, there's no such case for `libcrypto` which is `libcrypto.so.44.0.1` with libressl. This is the same SSL library that OpenBSD uses, some linux distributions use it too.