### PR TITLE
improved spawn

### DIFF
--- a/src/pipe.lisp
+++ b/src/pipe.lisp
@@ -1,7 +1,5 @@
 (in-package :cl-async)
 
-(defclass pipe (streamish) ())
-
 (defclass pipe-mixin () ())
 (defclass pipe (pipe-mixin socket) ())
 (defclass pipe-server (pipe-mixin socket-server) ())

--- a/src/process.lisp
+++ b/src/process.lisp
@@ -148,10 +148,8 @@
                            for in-p = t then nil
                            when pipe-or-stream
                              do (let ((pipe (streamish pipe-or-stream)))
-                                  (when (or in-p (streamish-read-start
-                                                  (streamish pipe)))
-                                    (setf (socket-connected (streamish pipe)) t)
-                                (write-pending-socket-data pipe))))
+                                  (when (or in-p (streamish-read-start pipe))
+                                    (setf (socket-connected (streamish pipe)) t))))
                      (apply #'values
                             (make-instance 'process
                                            :c handle

--- a/src/process.lisp
+++ b/src/process.lisp
@@ -5,9 +5,7 @@
 ;; TBD: support inheritance of custom fds
 ;; TBD: utf-8 pipe support
 ;; TBD: check process handles during walk using generic function
-;; TBD: custom env
 ;; TBD: custom process name
-;; TBD: custom cwd
 ;; TBD: custom string encoding
 ;; TBD: process flags (detached etc.)
 


### PR DESCRIPTION
The call to `write-pending-socket-data` in `spawn` triggers a `streamish-broken-pipe` error (when attempting to write to stdout and stderr streams) which breaks tests.

Data provided through the `:data` argument to the stdin container is flushed at <https://github.com/orthecreedence/cl-async/blob/master/src/socket.lisp#L276> meaning that the call can be removed altogether.

I have also removed what seems to be a spurious `defclass` in `pipe.lisp`