### PR TITLE
fixed all tests on x86 GNU/voidlinux

### DIFF
--- a/src/fsevent.lisp
+++ b/src/fsevent.lisp
@@ -52,7 +52,9 @@
               (uv:uv-fs-event-start
                handle (cffi:callback fs-event-callback)
                (namestring path)
-               4 #++ 0))
+               #+(or darwin windows)
+               (cffi:foreign-enum-value 'uv:uv-fs-event-flags :recursive)
+               #+linux 0))
         (cond ((zerop res)
                fs-monitor)
               (t

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -46,8 +46,6 @@
            #:with-interval
            #:remove-interval
            #:make-event
-           #:watch-fd
-           #:fd-add
 
            ;; notifier exports
            #:notifier

--- a/src/process.lisp
+++ b/src/process.lisp
@@ -104,7 +104,7 @@
   (:STREAM [:READ-CB ...] ...) same as PIPE, but uses async
     stream instead of a pipe.
 
- ENV is an alist of (VAR . VALUE) pairs specifying the environment variables
+  ENV is an alist of (VAR . VALUE) pairs specifying the environment variables
   of the spawned process. Note that both VAR and VALUE must be strings.
 
   WORKING-DIRECTORY specifies the current working directory of the spawned

--- a/src/streamish.lisp
+++ b/src/streamish.lisp
@@ -137,11 +137,11 @@
     (do-close-streamish uvstream
                        :force force)))
 
-(defun write-to-uvstream (uvstream data &key start end)
+(defun write-to-uvstream (uvstream data &key (start 0) (end (length data)))
   "Util function to write data directly to a uv stream object."
-  (let* ((bufsize (length data))
+  (let* ((bufsize (- end start))
          (buffer (static-vectors:make-static-vector bufsize)))
-    (replace buffer data)
+    (replace buffer data :start2 start :end2 end)
     (let ((req (uv:alloc-req :write))
           (buf (uv:alloc-uv-buf (static-vectors:static-vector-pointer buffer) bufsize)))
       (let ((res (uv:uv-write req uvstream buf 1 (cffi:callback streamish-write-cb))))

--- a/src/util/helpers.lisp
+++ b/src/util/helpers.lisp
@@ -87,9 +87,7 @@
 (defun save-callbacks (pointer callbacks)
   "Save a set of callbacks, keyed by the given pointer."
   (with-lock
-    (let ((callbacks (if (listp callbacks)
-                         callbacks
-                         (list callbacks))))
+    (let ((callbacks (alexandria:ensure-list callbacks)))
       (setf (gethash (make-pointer-eql-able pointer) *function-registry*) callbacks))))
 
 (defun get-callbacks (pointer)

--- a/test/dns.lisp
+++ b/test/dns.lisp
@@ -84,7 +84,7 @@
             (declare (ignore service))
             (setf host host*))
           :event-cb (lambda (ev) (error ev))))
-    (is (string= host "google-public-dns-a.google.com"))))
+    (is (string= host "dns.google"))))
 
 (test reverse-dns-lookup-ipv6
   "Test IPV6 family"
@@ -98,7 +98,7 @@
               (setf host host*))
             :event-cb (lambda (ev) (error ev))))
         (error (e) (format nil "(~a) ~a" (as:event-errcode e) (as:event-errmsg e))))
-    (is (string= host "google-public-dns-a.google.com"))))
+    (is (string= host "dns.google"))))
 
 (test dns-lookup-mem-leak
   "Test dns-lookup memory leaks"

--- a/test/process.lisp
+++ b/test/process.lisp
@@ -120,7 +120,7 @@
       ;; send SIGINT
       (as:process-kill process 2))))
 
-(test process-env ; TODO make more portable
+(test process-env
   (with-test-event-loop ()
     (with-temporary-directory (dir)
       (test-timeout 3)


### PR DESCRIPTION
All tests now run on my system and hopefully everywhere else too.
Summary of changes:
* according to the libuv docs the `UV_FS_EVENT_RECURSIVE` flag is not supported on linux. However to my pleasant surprise, providing 0 worked on directories anyways.
* fixed improperly indented doc line from my previous pull req
* use `alexandria:ensure-list` in `util/helpers.lisp`
* google's public dns has changed
* fixed `fs-monitor` test - after fixing the flag issue, the problem was that the fs handle was keeping the loop alive, causing a timeout. Also removed possibly spurious `as:delay` surrounding the checking code.

This closes <https://github.com/orthecreedence/cl-async/issues/139> and <https://github.com/orthecreedence/cl-async/issues/137>. Also note that <https://github.com/orthecreedence/cl-async/issues/65> is possibly already solved.