### PR TITLE
when streamish is provided, always create stramish-error instead of event-error

### DIFF
--- a/src/streamish.lisp
+++ b/src/streamish.lisp
@@ -82,6 +82,12 @@
   if THING is a streamish.")
   (:method ((streamish streamish)) streamish))
 
+(defmethod errno-event ((streamish streamish) (errno t))
+  (make-instance 'streamish-error
+                 :streamish streamish
+                 :code errno
+                 :msg (error-str errno)))
+
 (defmethod errno-event ((streamish streamish) (errno (eql (uv:errval :eof))))
   (make-instance 'streamish-eof :streamish streamish))
 


### PR DESCRIPTION
Without this, if an error on `streamish` occurs and there is no method for that errno specifically, it falls through to the default method which creates `even-error` and reference to the `streamish` is lost (for the client code).

I discovered this by accident: my cl-async server worked mostly fine, but every 1000 or so connections I got 113 EHOSTUNREACH error and in the client code I could not retrieve on which of the open sockets this had happened, because the `event-cb` already got it as instance of `event-error`.

It should be mostly backwards compatible, except at https://github.com/orthecreedence/cl-async/blob/f6423e44404a44434d803605e0d2e17199158e28/src/streamish.lisp#L25-L27 the callback would be executed with as:delay instead of directly. I don't understand why the delay is there but now it should be more consistent with other events on streamish.