### PR TITLE
Fixed most of broken tests

### DIFF
--- a/src/streamish.lisp
+++ b/src/streamish.lisp
@@ -143,9 +143,11 @@
     (do-close-streamish uvstream
                        :force force)))
 
-(defun write-to-uvstream (uvstream data &key (start 0) (end (length data)))
+(defun write-to-uvstream (uvstream data &key start end)
   "Util function to write data directly to a uv stream object."
-  (let* ((bufsize (- end start))
+  (let* ((start (or start 0))
+         (end (or end (length data)))
+         (bufsize (- end start))
          (buffer (static-vectors:make-static-vector bufsize)))
     (replace buffer data :start2 start :end2 end)
     (let ((req (uv:alloc-req :write))


### PR DESCRIPTION
The breakage was caused by a call to write-to-uvstream which specified
both :start and :end as NIL.

Unfortunately, it was easier to alter write-to-uvstream than change
the calling code.


For the reference, the test report looked like this:
```
Running test suite CL-ASYNC-TEST-CORE
 Running test DATA-POINTERS .
 Running test IPV4-ADDRESS ..........
 Running test IPV6-ADDRESS ............
 Running test POINTER-CALLBACKS ...
 Running test POINTER-DATA ...
 Running test EVENT-LOOP-STARTS .
 Running test EVENT-LOOP-EXIT .
 Running test CATCH-APP-ERRORS ..
 Running test DATA-AND-FN-POINTERS ..
 Running test EXIT-CALLBACKS .
 Running test DELAY-SIMPLE .
 Running test DELAY-TIMER .
 Running test DELAY-MULTI ...
 Running test INTERVAL .
 Running test DNS-SIMPLE .
 Running test DNS-MULTI ..
 Running test DNS-LOOKUP-IPV4 .
 Running test DNS-LOOKUP-IPV6 .
 Running test DNS-FAIL ..
 Running test REVERSE-DNS-LOOKUP-IPV4 .
 Running test REVERSE-DNS-LOOKUP-IPV6 .
 Running test DNS-LOOKUP-MEM-LEAK .
 Running test REVERSE-DNS-LOOKUP-MEM-LEAK .
 Running test TCP-SIMPLE-CLIENT-SERVER X
WARNING:
   aborting connection to localhost:31388 on a tcp socket that is being closed: #<CL-ASYNC:TCP-SOCKET {1004998483}> (uvstream #.(SB-SYS:INT-SAP #X7F6BB00214A0))


 Running test TCP-CONNECT-FAIL ..
 Running test TCP-SERVER-CLOSE X
 Running test TCP-SERVER-STREAM X
 Running test TEST-ADDRESS-IN-USE ..
 Running test WRITE-SEQ-WITH-OFFSET X
 Running test PIPE-SIMPLE-CLIENT-SERVER X
 Running test PIPE-CONNECT-FAIL X
 Running test PIPE-SERVER-CLOSE X
 Running test PIPE-SERVER-STREAM X
 Running test STREAM-READ-WRITE-SEQUENCE X
 Running test SIGNAL-HANDLER-ADD-REMOVE .
 Running test IDLE .
 Running test POLL-FD .
 Running test MKDTEMP ..
 Running test MKDTEMP-FAIL .
 Running test SPAWN-SIMPLE .....
 Running test SPAWN-REDIRECT-OUTPUT .....X
 Running test SPAWN-REDIRECT-ERROR-OUTPUT .....X
 Running test SPAWN-REDIRECT-STREAM .....X
 Running test SPAWN-EXEC-FAILURE .
 Running test PROCESS-KILL ....
 Running test PROCESS-ENV .
 Running test FS-MONITOR .......
 Running test FS-WATCH-FAILURE .
 Did 109 checks.
    Pass: 97 (88%)
    Skip: 0 ( 0%)
    Fail: 12 (11%)
```