### PR TITLE
Do not require libeay32 under non-Windows OSes

### DIFF
--- a/src/ssl/package.lisp
+++ b/src/ssl/package.lisp
@@ -72,7 +72,8 @@
 
   (cffi:use-foreign-library libssl)
 
-  (cffi:define-foreign-library libeay32
-    (:windows "libeay32.dll"))
-
-  (cffi:use-foreign-library libeay32))
+  #+windows
+  (progn
+    (cffi:define-foreign-library libeay32
+      (:windows "libeay32.dll"))
+    (cffi:use-foreign-library libeay32)))


### PR DESCRIPTION
Hello!
While trying to package cl-async using application with [Shinmera's deploy](https://github.com/Shinmera/deploy), I was getting error regarding libeay32 library (deploy forces all cffi libraries to be present as files). Looks like libeay32 is only required on Windows, so this PR removes dependency on that library under non-Windows OSes.