### PR TITLE
Fix for issue #188

### DIFF
--- a/src/dns.lisp
+++ b/src/dns.lisp
@@ -3,6 +3,9 @@
 (define-condition dns-error (event-error) ()
   (:documentation "Passed to a failure callback when a DNS error occurs on a connection."))
 
+(defmethod errno-event ((streamish t) (errno (eql (uv:errval :eai-nodata))))
+  (make-instance 'dns-error :code errno :msg (error-str errno)))
+
 (define-c-callback dns-cb :void ((req :pointer) (status :int) (addrinfo :pointer))
   "Callback for DNS lookups."
   (let* ((callbacks (get-callbacks req))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -102,6 +102,7 @@
            #:close-streamish
            #:streamish-info
            #:streamish-error
+           #:streamish-enoent
            #:streamish-eof
            #:streamish-broken-pipe
            #:streamish-canceled

--- a/src/ssl/package.lisp
+++ b/src/ssl/package.lisp
@@ -105,6 +105,9 @@
 
   (cffi:use-foreign-library libssl)
 
+  (when (cffi:foreign-symbol-pointer "TLS_method")
+    (pushnew ':tls-method *features*))
+
   #+windows
   (progn
     (cffi:define-foreign-library libeay32

--- a/src/ssl/tcp.lisp
+++ b/src/ssl/tcp.lisp
@@ -404,7 +404,7 @@
          (server (as:tcp-server bind-address
                                 port
                                 read-cb
-                                event-cb
+                                :event-cb event-cb
                                 :connect-cb wrap-connect-cb
                                 :backlog backlog
                                 :stream stream

--- a/src/streamish.lisp
+++ b/src/streamish.lisp
@@ -54,6 +54,9 @@
                (format s "~a: ~a: ~a" (streamish c) (event-errcode c) (event-errmsg c)))))
   (:documentation "Describes a general streamish error."))
 
+(define-condition streamish-enoent (streamish-error) ()
+  (:documentation "Passed to an event callback on Error: no such file or directory."))
+
 (define-condition streamish-eof (streamish-info) ()
   (:documentation "Passed to an event callback when stream EOF is reached."))
 
@@ -87,6 +90,9 @@
                  :streamish streamish
                  :code errno
                  :msg (error-str errno)))
+
+(defmethod errno-event ((streamish streamish) (errno (eql (uv:errval :enoent))))
+  (make-instance 'streamish-enoent :streamish streamish))
 
 (defmethod errno-event ((streamish streamish) (errno (eql (uv:errval :eof))))
   (make-instance 'streamish-eof :streamish streamish))

--- a/test/pipe.lisp
+++ b/test/pipe.lisp
@@ -45,7 +45,7 @@
 (test pipe-connect-fail
   "Make sure a pipe connection fails"
   (let ((num-err 0))
-    (signals as:filesystem-enoent
+    (signals as:streamish-enoent
       (async-let ()
         (test-timeout 2)
         (with-path-under-tmpdir (path "nosuchpipe")

--- a/test/tcp-ssl.lisp
+++ b/test/tcp-ssl.lisp
@@ -34,6 +34,7 @@
                                (unless (as:socket-closed-p sock)
                                  (as:close-socket sock))
                                (setf client-data (concat client-data (babel:octets-to-string data))))
+                             :event-cb
                              (lambda (ev) (error ev))
                              :data "ha")))
                 (as:write-socket-data sock "i "))))

--- a/test/tcp-ssl.lisp
+++ b/test/tcp-ssl.lisp
@@ -18,7 +18,6 @@
             (incf server-reqs)
             (setf server-data (concat server-data (babel:octets-to-string data)))
             (as:write-socket-data sock "thxlol "))
-          nil
           :certificate (asdf:system-relative-pathname :cl-async #P"test/ssl/certkey")
           :key  (asdf:system-relative-pathname :cl-async #P"test/ssl/certkey")
           :connect-cb (lambda (sock)


### PR DESCRIPTION
There are five changesets here.  The first four fix existing test failures to avoid needing to handwave test failures with the fifth patch -- the actual fix.

The main event (f0cc925), formalizes the patch suggested in issue #188.  This provides backward compatibility with OpenSSL 1.0.1 where the patch in the bug report does not.  Arguably, providing compatibility with old and probably broken OpenSSL versions is not doing anyone any favors.  But this seems a more complete solution.

This has been tested with `(cl-async-test::run-tests :ssl t)` on Linux with the following OpenSSL and SBCL versions:

| distribution | OpenSSL version | SBCL version |
| --- | --- | --- |
| debian-08  | 1.0.1t | 1.2.4.debian |
| debian-09 | 1.1.0l | 1.3.14.debian |
| debian-11 | 1.1.1k | 2.1.1.debian |
