### PR TITLE
docs: fix examples/dns-lookup.lisp

### DIFF
--- a/examples/dns-lookup.lisp
+++ b/examples/dns-lookup.lisp
@@ -3,15 +3,15 @@
 (ql:quickload :cl-async)
 
 (defun do-lookups ()
-  (dolist (lookup `(("google.com")
-                    ("musio.com" . ,as:+af-inet+)
-                    ("www.google.com" . ,as:+af-inet6+)))
-    (let ((host (car lookup))
-          (family (if (cdr lookup) (cdr lookup) as:+af-unspec+)))
+  (dolist (lookup `(("google.com" ,as:+af-unspec+)
+                    ("musio.com" ,as:+af-inet+)
+                    ("www.google.com" ,as:+af-inet6+)))
+    (destructuring-bind (host family) lookup
       (as:dns-lookup host
         (lambda (addr fam)
           (declare (ignore fam))
           (format t "~a resolved to ~s (~s)~%" host addr family))
+        :event-cb
         (lambda (ev)
           (format t "ev: ~a(~a): ~a~%" host family ev))
         :family family))))


### PR DESCRIPTION
The callback is a keyword element now.

Also simplified some of the default parameter handling to focus the code on as:dns-lookup.