### PR TITLE
Fix cl-async ASDF definition.

### DIFF
--- a/cl-async.asd
+++ b/cl-async.asd
@@ -43,12 +43,11 @@
                #:uiop)
   :components
   ((:module src
-    :serial t
     :components
     ((:file "package")
      (:file "event-loop" :depends-on ("package"))
      (:file "event" :depends-on ("package"))
-     (:file "dns" :depends-on ("package"))
+     (:file "dns" :depends-on ("package" "streamish"))
      (:file "streamish" :depends-on ("event-loop" "event"))
      (:file "async-stream" :depends-on ("streamish"))
      (:file "socket" :depends-on ("streamish" "async-stream"))

--- a/src/streamish.lisp
+++ b/src/streamish.lisp
@@ -1,5 +1,9 @@
 (in-package :cl-async)
 
+(defgeneric streamish (thing)
+  (:documentation "Returned associated streamish for THING or THING itself
+  if THING is a streamish."))
+
 (defgeneric errno-event (streamish errno)
   (:documentation "Make an event based on errno and streamish."))
 
@@ -80,10 +84,8 @@
    (drain-read-buffer :accessor streamish-drain-read-buffer :initarg :drain-read-buffer :initform t))
   (:documentation "Wraps around a streamish."))
 
-(defgeneric streamish (thing)
-  (:documentation "Returned associated streamish for THING or THING itself
-  if THING is a streamish.")
-  (:method ((streamish streamish)) streamish))
+(defmethod streamish ((streamish streamish))
+  streamish)
 
 (defmethod errno-event ((streamish streamish) (errno t))
   (make-instance 'streamish-error

--- a/src/util/helpers.lisp
+++ b/src/util/helpers.lisp
@@ -10,14 +10,6 @@
    data into write-socket-data."
   (coerce vector '(vector octet)))
 
-(defun make-buffer (&optional data)
-  "Create an octet buffer, optoinally filled with the given data."
-  (declare (type (or null octet-vector) data))
-  (let ((buffer (fast-io:make-output-buffer)))
-    (when data
-      (write-to-buffer data buffer))
-    buffer))
-
 (declaim (inline buffer-output))
 (defun buffer-output (buffer)
   "Grab the output from a buffer created with (make-buffer)."
@@ -30,6 +22,14 @@
   (declare (type octet-vector seq)
            (type fast-io::output-buffer buffer))
   (fast-io:fast-write-sequence seq buffer (or start 0) end))
+
+(defun make-buffer (&optional data)
+  "Create an octet buffer, optoinally filled with the given data."
+  (declare (type (or null octet-vector) data))
+  (let ((buffer (fast-io:make-output-buffer)))
+    (when data
+      (write-to-buffer data buffer))
+    buffer))
 
 (defun do-chunk-data (data buffer write-cb &key start end new-buffer)
   "Util function that splits data into the (length buffer) chunks and calls


### PR DESCRIPTION
Remove the `:serial t` component, which is not necessary because of the specific dependencies in the `:components` and fix the dependency for the `"dns"` component.

Fixes issue #194 