### PR TITLE
Remove defs of variables that are never read.

### DIFF
--- a/src/signal.lisp
+++ b/src/signal.lisp
@@ -69,8 +69,9 @@
   (let* ((callbacks (get-callbacks watcher))
          (signal-cb (getf callbacks :signal-cb))
          (event-cb (getf callbacks :event-cb))
-         (sig-data (deref-data-from-pointer watcher))
-         (ev (getf sig-data :ev)))
+         ;; (sig-data (deref-data-from-pointer watcher))
+         ;; (ev (getf sig-data :ev))
+         )
     (catch-app-errors event-cb
       (funcall signal-cb signo))))
 

--- a/src/signal.lisp
+++ b/src/signal.lisp
@@ -68,10 +68,7 @@
   "All signals come through here."
   (let* ((callbacks (get-callbacks watcher))
          (signal-cb (getf callbacks :signal-cb))
-         (event-cb (getf callbacks :event-cb))
-         ;; (sig-data (deref-data-from-pointer watcher))
-         ;; (ev (getf sig-data :ev))
-         )
+         (event-cb (getf callbacks :event-cb)))
     (catch-app-errors event-cb
       (funcall signal-cb signo))))
 

--- a/src/util/error.lisp
+++ b/src/util/error.lisp
@@ -63,7 +63,7 @@
    If event-cbs are called via run-event-cb, make sure the event-cb
    is NOT double-called with the same condition twice."
   (alexandria:once-only (event-cb)
-    (alexandria:with-gensyms (evcb err last-err thunk-fn continue-fn blk)
+    (alexandria:with-gensyms (err last-err thunk-fn continue-fn blk)
       `(let ((*evcb-err* '())
              (,last-err nil))
          (labels ((,continue-fn (error)

--- a/src/util/foreign.lisp
+++ b/src/util/foreign.lisp
@@ -63,7 +63,7 @@
 (defun addrinfo-to-string (addrinfo)
   "Given a (horrible) addrinfo C object pointer, grab either an IP4 or IP6
    address and return is as a string."
-  (let* ((type 'uv:addrinfo)
+  (let* (;(type 'uv:addrinfo)
          (family (uv-a:addrinfo-ai-family addrinfo))
          (err nil))
     (cffi:with-foreign-object (buf :unsigned-char 128)

--- a/src/util/foreign.lisp
+++ b/src/util/foreign.lisp
@@ -63,8 +63,7 @@
 (defun addrinfo-to-string (addrinfo)
   "Given a (horrible) addrinfo C object pointer, grab either an IP4 or IP6
    address and return is as a string."
-  (let* (;(type 'uv:addrinfo)
-         (family (uv-a:addrinfo-ai-family addrinfo))
+  (let* ((family (uv-a:addrinfo-ai-family addrinfo))
          (err nil))
     (cffi:with-foreign-object (buf :unsigned-char 128)
       (let ((ai-addr (uv-a:addrinfo-ai-addr addrinfo)))


### PR DESCRIPTION
Quiets a bunch of compiler warnings.