### PR TITLE
Redefine DEFINE-CONDITION-ALIAS.

### DIFF
--- a/src/util/helpers.lisp
+++ b/src/util/helpers.lisp
@@ -170,6 +170,9 @@
 
 (defmacro define-condition-alias (alias name)
   "Define an alias for the specified condition."
-  `(progn
-     (deftype ,alias () ',name)
-     (setf (find-class ',alias) (find-class ',name))))
+  `(define-condition ,alias (,name)
+     ())
+  ;; `(progn
+  ;;    (deftype ,alias () ',name)
+  ;;    (setf (find-class ',alias) (find-class ',name)))
+  )

--- a/src/util/helpers.lisp
+++ b/src/util/helpers.lisp
@@ -171,8 +171,4 @@
 (defmacro define-condition-alias (alias name)
   "Define an alias for the specified condition."
   `(define-condition ,alias (,name)
-     ())
-  ;; `(progn
-  ;;    (deftype ,alias () ',name)
-  ;;    (setf (find-class ',alias) (find-class ',name)))
-  )
+     ()))


### PR DESCRIPTION
Re-implement this by making a new class for the "alias" that inherits from the parent. This is no longer really aliasing, but at least SBCL's compiler really dislikes the original implementation of this macro.

Addresses #193