### PR TITLE
Use the proper signature for OPENSSL_init_ssl function call

### DIFF
--- a/src/ssl/tcp.lisp
+++ b/src/ssl/tcp.lisp
@@ -31,7 +31,8 @@
     (unless *ssl-init*
       (if (cffi:foreign-symbol-pointer "SSL_library_init" )
           (cffi:foreign-funcall "SSL_library_init" :void)
-          (cffi:foreign-funcall "OPENSSL_init_ssl" :int 0 :int 0))
+          (cffi:foreign-funcall "OPENSSL_init_ssl"
+                                :uint64 0 :pointer (cffi:null-pointer)))
       (when (cffi:foreign-symbol-pointer "SSL_load_error_strings")
         (cffi:foreign-funcall "SSL_load_error_strings" :void))
       (cffi:foreign-funcall "ERR_load_BIO_strings" :void)


### PR DESCRIPTION
The function accepts an `uint64` as its first argument and a pointer as the second one, and passing `:int 0` for both has been causing issues on 32-bit systems