### PR TITLE
Added SNI calls to socket setup when we have hostname.

### DIFF
--- a/src/ssl/tcp.lisp
+++ b/src/ssl/tcp.lisp
@@ -338,6 +338,11 @@
                                             sock/stream)))
                               (setf (socket-ssl-function sock) 'ssl-connect)
                               (let ((ssl (as-ssl-ssl (socket-as-ssl sock))))
+				(when host
+				  (cffi:with-foreign-string (host-name host)
+				    (if (eql 0 (ssl-set-tlsext-host-name ssl host-name))
+					(vom:debug "TLS SNI host name set.~%")
+					(vom:debug "Failed to set SNI host name, hostname: ~a.~%" host))))
                                 (ssl-connect ssl)
                                 (ssl-run-state ssl))
                               (when connect-cb

--- a/src/ssl/util.lisp
+++ b/src/ssl/util.lisp
@@ -134,6 +134,17 @@
 (cffi:defcfun ("TLSv1_method" ssl-tlsv1-method) :pointer)
 (cffi:defcfun ("TLSv1_client_method" ssl-tlsv1-client-method) :pointer)
 (cffi:defcfun ("TLSv1_server_method" ssl-tlsv1-server-method) :pointer)
+
+;; this is copied virtually verbatim from cl+ssl
+(cffi:defcfun ("SSL_ctrl" ssl-ctrl) :long
+  (ssl :pointer)
+  (cmd :int)
+  (larg :long)
+  (parg :pointer))
+
+(defun ssl-set-tlsext-host-name (ctx hostname)
+  (ssl-ctrl ctx 55 #|SSL_CTRL_SET_TLSEXT_HOSTNAME|# 0 #|TLSEXT_NAMETYPE_host_name|# hostname))
+
 #+:tls-method
 (progn (cffi:defcfun ("TLS_method" ssl-sslv23-method) :pointer)
        (cffi:defcfun ("TLS_client_method" ssl-sslv23-client-method) :pointer)


### PR DESCRIPTION
I had a server reject TLS connections that didn't carry an SNI extension.
I've only added enough to include the SNI extension, it's copied nearly verbatim from CL+SSL.
