### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/cl-async-base.asd
+++ b/cl-async-base.asd
@@ -1,0 +1,9 @@
+(defsystem cl-async-base
+  :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
+  :license "MIT"
+  :version "0.6.1"
+  :description "Base system for cl-async."
+  :depends-on (#:cffi #:cl-libuv #:bordeaux-threads)
+  :serial t
+  :components
+  ((:file "src/base")))

--- a/cl-async-repl.asd
+++ b/cl-async-repl.asd
@@ -1,4 +1,4 @@
-(asdf:defsystem cl-async-repl
+(defsystem cl-async-repl
   :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
   :license "MIT"
   :version "0.1"

--- a/cl-async-ssl.asd
+++ b/cl-async-ssl.asd
@@ -1,4 +1,4 @@
-(asdf:defsystem cl-async-ssl
+(defsystem cl-async-ssl
   :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
   :license "MIT"
   :version "0.6.0"

--- a/cl-async-test.asd
+++ b/cl-async-test.asd
@@ -1,4 +1,4 @@
-(asdf:defsystem cl-async-test
+(defsystem cl-async-test
   :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
   :license "MIT"
   :version "0.2"
@@ -30,4 +30,5 @@
                  (:file "run")
                  (:file "filesystem")
                  (:file "process")
-                 (:file "fsevent")))))
+                 (:file "fsevent"))))
+  :perform (test-op (o c) (symbol-call :cl-async-test :run-tests)))

--- a/cl-async-util.asd
+++ b/cl-async-util.asd
@@ -1,0 +1,17 @@
+(defsystem cl-async-util
+  :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
+  :license "MIT"
+  :version "0.6.1"
+  :description "Internal utilities for cl-async."
+  :depends-on (#:cffi
+               #:fast-io
+               #:vom
+               #:cl-libuv
+               #:cl-ppcre
+               #:cl-async-base)
+  :serial t
+  :components
+  ((:file "src/util/package")
+   (:file "src/util/helpers")
+   (:file "src/util/foreign")
+   (:file "src/util/error")))

--- a/cl-async.asd
+++ b/cl-async.asd
@@ -1,32 +1,4 @@
-(asdf:defsystem cl-async-base
-  :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
-  :license "MIT"
-  :version "0.6.1"
-  :description "Base system for cl-async."
-  :depends-on (#:cffi #:cl-libuv #:bordeaux-threads)
-  :serial t
-  :components
-  ((:file "src/base")))
-
-(asdf:defsystem cl-async-util
-  :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
-  :license "MIT"
-  :version "0.6.1"
-  :description "Internal utilities for cl-async."
-  :depends-on (#:cffi
-               #:fast-io
-               #:vom
-               #:cl-libuv
-               #:cl-ppcre
-               #:cl-async-base)
-  :serial t
-  :components
-  ((:file "src/util/package")
-   (:file "src/util/helpers")
-   (:file "src/util/foreign")
-   (:file "src/util/error")))
-
-(asdf:defsystem cl-async
+(defsystem cl-async
   :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
   :license "MIT"
   :version "0.6.1"


### PR DESCRIPTION
ASDF3 recommends declaring a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)
